### PR TITLE
Use prop-types library instead of react.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/coopermaruyama/tableau-react#readme",
   "peerDependencies": {
     "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.3.2",
+    "prop-types": "^15.6.0"
   },
   "dependencies": {
     "es6-promise": "^4.0.5",

--- a/src/TableauReport.jsx
+++ b/src/TableauReport.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import url from 'url';
 import { Promise } from 'es6-promise';
 import shallowequal from 'shallowequal';


### PR DESCRIPTION
React.PropTypes has moved into the prop-types package since React v15.5.