### PR TITLE
fix: remove sheet nesting

### DIFF
--- a/src/TableauReport.jsx
+++ b/src/TableauReport.jsx
@@ -167,8 +167,7 @@ class TableauReport extends React.Component {
       ...this.props.options,
       onFirstInteractive: () => {
         this.workbook = this.viz.getWorkbook();
-        this.sheets = this.workbook.getActiveSheet().getWorksheets();
-        this.sheet = this.sheets[0];
+        this.sheet = this.workbook.getActiveSheet();
 
         this.props.onLoad && this.props.onLoad(new Date());
       }


### PR DESCRIPTION
I tried with our own graph on tableau public, as well as the one from the tutorial ( https://public.tableau.com/views/WorldIndicators/GDPpercapita ). In both cases the issue is, that `getActiveSheet()` is already returning the sheet, so there is no method `getWorksheets()`. This is only failing the function, but whenever we try to change the filter, it is crashing the entire component.

@coopermaruyama do I also have to run the build job locally and commit the changed dist folder or will this run automatically?